### PR TITLE
Update wine source repository URL to use GitHub mirror

### DIFF
--- a/wsc
+++ b/wsc
@@ -792,7 +792,7 @@ case $X in
     echo -en $fRED "Deleting the old wine source tree                     $RES\n"
     rm -rf ./wine-vanilla
     echo -en $fRED "Getting a new copy of the wine source                 $RES\n"
-    git clone git://source.winehq.org/git/wine.git ./wine-vanilla
+    git clone https://github.com/wine-mirror/wine.git ./wine-vanilla
 
 ;;
 


### PR DESCRIPTION
This fixes fetching vanilla wine builds due to the old source.winehq.org URL redirecting to GitLab. (The script deadlocks)

To spare the WineHQ GitLab the bandwidth I updated the URL to point to the GitHub mirror.