### PR TITLE
Refactor wine download process to use git checkout instead of wget

### DIFF
--- a/wsc
+++ b/wsc
@@ -282,27 +282,47 @@ _RELEASE()
     $YLW ==> $RES "
 
     read Y
-    if [ $Y = "q" ]; then _DONE
+    if [ "$Y" = "q" ]; then _DONE
     else
 
-    echo -en "\n$dRED Checking out wine-$Y, please wait ...              $RES\n"
+        echo -en "\n$dRED Checking out wine-$Y, please wait ...              $RES\n"
 
-    rm -rf ./wine-vanilla
-    rm -rf ./wine-staging
-    mkdir -p --mode=0777 ./wine-vanilla
-    mkdir -p --mode=0777 ./wine-staging
-    
-    pushd ./wine-staging || exit
-    git clone https://github.com/wine-staging/wine-staging.git .
-    git checkout v$Y
-    popd || exit
+        # Process wine-staging:
+        if [ -d "./wine-staging/.git" ]; then
+            pushd ./wine-staging || exit
+            echo -en "$YLW Found existing wine-staging repository, cleaning up ...$RES\n"
+            git reset --hard
+            git clean -fdx
+            git pull
+            git checkout v$Y
+            popd || exit
+        else
+            mkdir -p --mode=0777 ./wine-staging
+            pushd ./wine-staging || exit
+            rm -rf ./*
+            git clone https://github.com/wine-staging/wine-staging.git .
+            git checkout v$Y
+            popd || exit
+        fi
 
-    pushd ./wine-vanilla || exit
-    git clone https://github.com/wine-mirror/wine.git .
-    git checkout wine-$Y
-    popd || exit
+        # Process wine-vanilla:
+        if [ -d "./wine-vanilla/.git" ]; then
+            pushd ./wine-vanilla || exit
+            echo -en "$YLW Found existing wine-vanilla repository, cleaning up ...$RES\n"
+            git reset --hard
+            git clean -fdx
+            git pull
+            git checkout wine-$Y
+            popd || exit
+        else
+            mkdir -p --mode=0777 ./wine-vanilla
+            pushd ./wine-vanilla || exit
+            rm -rf ./*
+            git clone https://github.com/wine-mirror/wine.git .
+            git checkout wine-$Y
+            popd || exit
+        fi
     fi
-
 }
 
 _RV_COMMIT()

--- a/wsc
+++ b/wsc
@@ -285,27 +285,22 @@ _RELEASE()
     if [ $Y = "q" ]; then _DONE
     else
 
-    echo -en "\n$dRED Downloading wine-$Y, please wait ...              $RES\n"
+    echo -en "\n$dRED Checking out wine-$Y, please wait ...              $RES\n"
 
     rm -rf ./wine-vanilla
     rm -rf ./wine-staging
-
-    mkdir -p --mode=0777 ./cache
     mkdir -p --mode=0777 ./wine-vanilla
     mkdir -p --mode=0777 ./wine-staging
-    cd ./cache
+    
+    pushd ./wine-staging || exit
+    git clone https://github.com/wine-staging/wine-staging.git .
+    git checkout v$Y
+    popd || exit
 
-    wget -q https://github.com/wine-staging/wine-staging/archive/v$Y.tar.gz
-    tar -xzf ./v$Y.tar.gz
-    cd wine-staging-$Y
-    cp -r ./* ../../wine-staging
-    cd ..
-
-    wget -q https://github.com/wine-mirror/wine/archive/wine-$Y.tar.gz
-    tar -xzf ./wine-$Y.tar.gz
-    cd wine-wine-$Y
-    cp -r ./* ../../wine-vanilla
-    cd ../../
+    pushd ./wine-vanilla || exit
+    git clone https://github.com/wine-mirror/wine.git .
+    git checkout wine-$Y
+    popd || exit
     fi
 
 }

--- a/wsc
+++ b/wsc
@@ -776,27 +776,49 @@ case $X in
 [9]* )
     clear
     echo -en $fRED "Resetting the staging source tree                  $RES\n"
+    if [ ! -d "./wine-staging" ]; then
+        mkdir -p --mode=0777 ./wine-staging
+        echo -en "$YLW 'wine-staging' directory created$RES\n"
+    fi
     pushd ./wine-staging || exit
-    git reset --hard
-    git clean -fdx
-    echo -en $fRED "Checking out the latest HEAD of the wine-staging source         $RES\n"
-    git checkout master
-    git pull
-    popd || exit
-
+    if [ -d ".git" ]; then
+        git reset --hard
+        git clean -fdx
+        echo -en $fRED "Checking out the latest HEAD of the wine-staging source         $RES\n"
+        git checkout master
+        git pull
+        popd || exit
+    else
+        echo -en "$YLW No git repository found in wine-staging, cloning repository...$RES\n"
+        rm -rf ./*
+        git clone https://github.com/wine-staging/wine-staging .
+        git checkout master
+        popd || exit
+    fi
 ;;
 
 [0]* )
     clear
     echo -en $fRED "Resetting the wine source tree                     $RES\n"
+    if [ ! -d "./wine-vanilla" ]; then
+        mkdir -p --mode=0777 ./wine-vanilla
+        echo -en "$YLW 'wine-vanilla' directory created$RES\n"
+    fi
     pushd ./wine-vanilla || exit
-    git reset --hard
-    git clean -fdx
-    echo -en $fRED "Checking out the latest HEAD of the wine source                 $RES\n"
-    git checkout master
-    git pull
-    popd || exit
-
+    if [ -d ".git" ]; then
+        git reset --hard
+        git clean -fdx
+        echo -en $fRED "Checking out the latest HEAD of the wine source                 $RES\n"
+        git checkout master
+        git pull
+        popd || exit
+    else
+        echo -en "$YLW No git repository found in wine-vanilla, cloning repository...$RES\n"
+        rm -rf ./*
+        git clone https://github.com/wine-mirror/wine .
+        git checkout master
+        popd || exit
+    fi
 ;;
 
 [a]* )

--- a/wsc
+++ b/wsc
@@ -775,19 +775,27 @@ case $X in
 
 [9]* )
     clear
-    echo -en $fRED "Deleting the old staging source tree                  $RES\n"
-    rm -rf ./wine-staging
-    echo -en $fRED "Getting a new copy of the wine-staging source         $RES\n"
-    git clone https://github.com/wine-staging/wine-staging.git ./wine-staging
+    echo -en $fRED "Resetting the staging source tree                  $RES\n"
+    pushd ./wine-staging || exit
+    git reset --hard
+    git clean -fdx
+    echo -en $fRED "Checking out the latest HEAD of the wine-staging source         $RES\n"
+    git checkout master
+    git pull
+    popd || exit
 
 ;;
 
 [0]* )
     clear
-    echo -en $fRED "Deleting the old wine source tree                     $RES\n"
-    rm -rf ./wine-vanilla
-    echo -en $fRED "Getting a new copy of the wine source                 $RES\n"
-    git clone git://source.winehq.org/git/wine.git ./wine-vanilla
+    echo -en $fRED "Resetting the wine source tree                     $RES\n"
+    pushd ./wine-vanilla || exit
+    git reset --hard
+    git clean -fdx
+    echo -en $fRED "Checking out the latest HEAD of the wine source                 $RES\n"
+    git checkout master
+    git pull
+    popd || exit
 
 ;;
 


### PR DESCRIPTION
This gets rid of a dependency on wget, and allows you to assume the wine-vanilla and wine-staging folders are git repositories, saving on bandwidth for other steps.